### PR TITLE
feat: cross-mode analytics (Phase 2)

### DIFF
--- a/src/app/deadly-assault/page.tsx
+++ b/src/app/deadly-assault/page.tsx
@@ -20,6 +20,10 @@ import { CharacterPerformanceTable } from "@/components/deadly-assault/character
 import { DeadlyAssaultTrend } from "@/components/deadly-assault/deadly-assault-trend";
 import { DaAnalytics } from "@/components/deadly-assault/da-analytics";
 import { PageHeader } from "@/components/shared/page-header";
+import { RecordsPanel } from "@/components/analytics/records-panel";
+import { ElementUsageTrend } from "@/components/analytics/element-usage-trend";
+import { AgentSynergyHeatmap } from "@/components/analytics/agent-synergy-heatmap";
+import { buildDaRecords, buildDaElementUsage, buildDaTeams } from "@/lib/analytics-extractors";
 
 
 export default async function DeadlyAssaultPage() {
@@ -112,6 +116,7 @@ export default async function DeadlyAssaultPage() {
           <div>
             <TabsList>
               <TabsTrigger value="overview">Analytics</TabsTrigger>
+              <TabsTrigger value="insights">Insights</TabsTrigger>
               <TabsTrigger value="deep-dive">Deep Dive</TabsTrigger>
               <TabsTrigger value="history">History</TabsTrigger>
               <TabsTrigger value="teams">Teams</TabsTrigger>
@@ -122,6 +127,17 @@ export default async function DeadlyAssaultPage() {
           <TabsContent value="overview" className="mt-6">
             {/* New analytics-first overview */}
             <DaAnalytics data={allData || []} />
+          </TabsContent>
+          <TabsContent value="insights" className="mt-6">
+            <div className="space-y-6">
+              <RecordsPanel
+                title="Personal Bests"
+                accent="#f5c842"
+                records={buildDaRecords(allData || [])}
+              />
+              <ElementUsageTrend accent="#f5c842" data={buildDaElementUsage(allData || [])} />
+              <AgentSynergyHeatmap accent="#f5c842" teams={buildDaTeams(allData || [])} />
+            </div>
           </TabsContent>
           <TabsContent value="deep-dive" className="mt-6">
             <div className="space-y-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,9 @@
 import Link from "next/link"
+import { getAllDeadlyAssaultData } from "@/lib/deadly-assault"
+import { getAllShiyuDefenseData } from "@/lib/shiyu-defense"
+import { getAllVoidFrontData } from "@/lib/void-front"
+import { InflationTracker } from "@/components/analytics/inflation-tracker"
+import { buildDaInflation, buildHadalInflation, buildVfInflation } from "@/lib/analytics-extractors"
 
 const modes = [
   {
@@ -57,7 +62,19 @@ const modes = [
   },
 ]
 
-export default function Home() {
+export default async function Home() {
+  const [daData, shiyuData, vfData] = await Promise.all([
+    getAllDeadlyAssaultData().catch(() => []),
+    getAllShiyuDefenseData().catch(() => []),
+    getAllVoidFrontData().catch(() => []),
+  ])
+
+  const inflationSeries = [
+    { name: 'Deadly Assault', color: '#f5c842', points: buildDaInflation(daData) },
+    { name: 'Hadal Blacksite', color: '#00d4ff', points: buildHadalInflation(shiyuData) },
+    { name: 'Void Front', color: '#a855f7', points: buildVfInflation(vfData) },
+  ].filter(s => s.points.length > 0)
+
   return (
     <div className="zzz-hero-bg min-h-[calc(100vh-4rem)] relative">
       <div
@@ -148,6 +165,9 @@ export default function Home() {
             </Link>
           ))}
         </div>
+
+        {/* Inflation tracker — cross-mode score% over time */}
+        {inflationSeries.length > 0 && <InflationTracker series={inflationSeries} />}
 
         {/* Footer info row */}
         <div className="flex flex-wrap gap-6 items-center pt-4 border-t border-[#1e2438]">

--- a/src/app/shiyu-defense/page.tsx
+++ b/src/app/shiyu-defense/page.tsx
@@ -18,11 +18,6 @@ import { ShiyuTeamsAggregationTable } from "@/components/shiyu-defense/teams-agg
 import { ShiyuFloorsAggregationTable } from "@/components/shiyu-defense/floors-aggregation-table"
 // New v2 components (score-based) — analytics-first
 import { HadalAnalytics } from "@/components/shiyu-defense-v2/hadal-analytics"
-// Legacy v2 fallback components
-import { HadalTrend } from "@/components/shiyu-defense-v2/hadal-trend"
-import { ScoreProgressionChartV2 } from "@/components/shiyu-defense-v2/score-progression-chart"
-import { HadalSummaryCards } from "@/components/shiyu-defense-v2/hadal-summary-cards"
-import { HadalBreakdownCharts } from "@/components/shiyu-defense-v2/hadal-breakdown-charts"
 // Cross-mode insight components
 import { RecordsPanel } from "@/components/analytics/records-panel"
 import { ElementUsageTrend } from "@/components/analytics/element-usage-trend"

--- a/src/app/shiyu-defense/page.tsx
+++ b/src/app/shiyu-defense/page.tsx
@@ -23,6 +23,11 @@ import { HadalTrend } from "@/components/shiyu-defense-v2/hadal-trend"
 import { ScoreProgressionChartV2 } from "@/components/shiyu-defense-v2/score-progression-chart"
 import { HadalSummaryCards } from "@/components/shiyu-defense-v2/hadal-summary-cards"
 import { HadalBreakdownCharts } from "@/components/shiyu-defense-v2/hadal-breakdown-charts"
+// Cross-mode insight components
+import { RecordsPanel } from "@/components/analytics/records-panel"
+import { ElementUsageTrend } from "@/components/analytics/element-usage-trend"
+import { AgentSynergyHeatmap } from "@/components/analytics/agent-synergy-heatmap"
+import { buildHadalRecords, buildHadalElementUsage, buildHadalTeams } from "@/lib/analytics-extractors"
 
 
 export default async function ShiyuDefensePage() {
@@ -152,6 +157,7 @@ export default async function ShiyuDefensePage() {
           <div>
             <TabsList>
               {hasV2Data && <TabsTrigger value="hadal-v2">Hadal Blacksite</TabsTrigger>}
+              {hasV2Data && <TabsTrigger value="insights">Insights</TabsTrigger>}
               {hasV1Data && <TabsTrigger value="overview">Legacy (V1)</TabsTrigger>}
               <TabsTrigger value="history">History</TabsTrigger>
               <TabsTrigger value="teams">Teams</TabsTrigger>
@@ -163,6 +169,20 @@ export default async function ShiyuDefensePage() {
             <TabsContent value="hadal-v2" className="mt-6">
               {/* HadalAnalytics reads the raw hadal_info_v2 schema directly */}
               <HadalAnalytics data={v2Data} />
+            </TabsContent>
+          )}
+
+          {hasV2Data && (
+            <TabsContent value="insights" className="mt-6">
+              <div className="space-y-6">
+                <RecordsPanel
+                  title="Personal Bests"
+                  accent="#00d4ff"
+                  records={buildHadalRecords(v2Data)}
+                />
+                <ElementUsageTrend accent="#00d4ff" data={buildHadalElementUsage(v2Data)} />
+                <AgentSynergyHeatmap accent="#00d4ff" teams={buildHadalTeams(v2Data)} />
+              </div>
             </TabsContent>
           )}
 

--- a/src/app/void-front/page.tsx
+++ b/src/app/void-front/page.tsx
@@ -12,6 +12,10 @@ import { VfAnalytics } from "@/components/void-front/vf-analytics";
 import { percentile } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { PageHeader } from "@/components/shared/page-header";
+import { RecordsPanel } from "@/components/analytics/records-panel";
+import { ElementUsageTrend } from "@/components/analytics/element-usage-trend";
+import { AgentSynergyHeatmap } from "@/components/analytics/agent-synergy-heatmap";
+import { buildVfRecords, buildVfElementUsage, buildVfTeams } from "@/lib/analytics-extractors";
 
 export default async function VoidFrontPage() {
   const allData = await getAllVoidFrontData();
@@ -155,6 +159,7 @@ export default async function VoidFrontPage() {
           <div>
             <TabsList>
               <TabsTrigger value="analytics">Analytics</TabsTrigger>
+              <TabsTrigger value="insights">Insights</TabsTrigger>
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="history">History</TabsTrigger>
               <TabsTrigger value="teams">Teams</TabsTrigger>
@@ -163,6 +168,18 @@ export default async function VoidFrontPage() {
 
           <TabsContent value="analytics" className="mt-6">
             <VfAnalytics data={allData || []} />
+          </TabsContent>
+
+          <TabsContent value="insights" className="mt-6">
+            <div className="space-y-6">
+              <RecordsPanel
+                title="Personal Bests"
+                accent="#a855f7"
+                records={buildVfRecords(allData || [])}
+              />
+              <ElementUsageTrend accent="#a855f7" data={buildVfElementUsage(allData || [])} />
+              <AgentSynergyHeatmap accent="#a855f7" teams={buildVfTeams(allData || [])} />
+            </div>
           </TabsContent>
 
           <TabsContent value="overview" className="mt-6">

--- a/src/components/analytics/agent-synergy-heatmap.test.tsx
+++ b/src/components/analytics/agent-synergy-heatmap.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { AgentSynergyHeatmap } from './agent-synergy-heatmap'
+
+describe('AgentSynergyHeatmap', () => {
+  it('renders empty state with no teams', () => {
+    render(<AgentSynergyHeatmap teams={[]} />)
+    expect(screen.getByText(/No team data available/i)).toBeInTheDocument()
+  })
+
+  it('aggregates pair counts and renders the most common pair first', () => {
+    render(
+      <AgentSynergyHeatmap
+        teams={[
+          { agentIds: [1, 2, 3], agentIcons: {} },
+          { agentIds: [1, 2, 4], agentIcons: {} },
+          { agentIds: [3, 4], agentIcons: {} },
+        ]}
+      />
+    )
+    // Pair (1,2) appears in two teams
+    expect(screen.getByText('2×')).toBeInTheDocument()
+    // Several pairs appear once
+    const ones = screen.getAllByText('1×')
+    expect(ones.length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/analytics/agent-synergy-heatmap.tsx
+++ b/src/components/analytics/agent-synergy-heatmap.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { useMemo } from 'react'
+import Image from 'next/image'
+
+export interface SynergyTeam {
+  agentIds: number[]
+  agentIcons: Record<number, string>
+  /** Optional score, used for avg-score column when present. */
+  score?: number
+}
+
+interface AgentSynergyHeatmapProps {
+  teams: SynergyTeam[]
+  accent?: string
+  /** Top N pairs to display. */
+  limit?: number
+}
+
+interface PairStat {
+  a: number
+  b: number
+  count: number
+  scoreSum: number
+  scoreSamples: number
+}
+
+function pairKey(x: number, y: number): string {
+  return x < y ? `${x}-${y}` : `${y}-${x}`
+}
+
+export function AgentSynergyHeatmap({
+  teams,
+  accent = '#00d4ff',
+  limit = 12,
+}: AgentSynergyHeatmapProps) {
+  const { pairs, maxCount, iconLookup } = useMemo(() => {
+    const stats = new Map<string, PairStat>()
+    const icons: Record<number, string> = {}
+    for (const t of teams) {
+      Object.assign(icons, t.agentIcons)
+      const ids = Array.from(new Set(t.agentIds))
+      for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+          const a = ids[i], b = ids[j]
+          const key = pairKey(a, b)
+          const existing = stats.get(key) ?? {
+            a: Math.min(a, b),
+            b: Math.max(a, b),
+            count: 0,
+            scoreSum: 0,
+            scoreSamples: 0,
+          }
+          existing.count++
+          if (typeof t.score === 'number') {
+            existing.scoreSum += t.score
+            existing.scoreSamples++
+          }
+          stats.set(key, existing)
+        }
+      }
+    }
+    const sorted = Array.from(stats.values()).sort((x, y) => y.count - x.count).slice(0, limit)
+    const max = sorted[0]?.count ?? 1
+    return { pairs: sorted, maxCount: max, iconLookup: icons }
+  }, [teams, limit])
+
+  if (pairs.length === 0) {
+    return (
+      <section
+        className="p-6 text-center text-[#6b7280] text-sm"
+        style={{
+          background: `${accent}0d`,
+          border: `1px solid ${accent}33`,
+          clipPath:
+            'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
+        }}
+      >
+        No team data available for synergy analysis.
+      </section>
+    )
+  }
+
+  const hasScores = pairs.some(p => p.scoreSamples > 0)
+
+  return (
+    <section
+      className="p-5"
+      style={{
+        background: `${accent}0d`,
+        border: `1px solid ${accent}33`,
+        clipPath:
+          'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
+      }}
+    >
+      <div className="text-[10px] font-bold tracking-[0.2em] uppercase mb-1" style={{ color: accent, opacity: 0.8 }}>
+        Agent Synergy
+      </div>
+      <h3 className="text-lg font-black text-[#e8e0cc] mb-1">Most-paired agents</h3>
+      <p className="text-xs text-[#6b7280] mb-4">
+        How often each pair of agents shows up on the same team.
+      </p>
+      <ul className="flex flex-col gap-1.5">
+        {pairs.map(p => {
+          const intensity = p.count / maxCount
+          const avgScore = p.scoreSamples > 0 ? Math.round(p.scoreSum / p.scoreSamples) : null
+          return (
+            <li
+              key={`${p.a}-${p.b}`}
+              className="flex items-center gap-3 px-3 py-2 bg-[#0d0f17] border border-[#1e2438]"
+              style={{
+                clipPath:
+                  'polygon(0 0, calc(100% - 6px) 0, 100% 6px, 100% 100%, 6px 100%, 0 calc(100% - 6px))',
+              }}
+            >
+              <div className="flex items-center gap-1 shrink-0">
+                {[p.a, p.b].map(id => {
+                  const url = iconLookup[id]
+                  return url ? (
+                    <Image
+                      key={id}
+                      src={url}
+                      alt={`Agent ${id}`}
+                      width={32}
+                      height={32}
+                      className="w-8 h-8 border border-[#1e2438]"
+                      unoptimized
+                    />
+                  ) : (
+                    <span
+                      key={id}
+                      className="w-8 h-8 inline-flex items-center justify-center text-[10px] text-[#6b7280] border border-[#1e2438]"
+                    >
+                      {id}
+                    </span>
+                  )
+                })}
+              </div>
+              <div className="flex-1 h-2 bg-[#1e2438] relative overflow-hidden">
+                <div
+                  className="h-full"
+                  style={{
+                    width: `${intensity * 100}%`,
+                    background: accent,
+                    opacity: 0.3 + intensity * 0.6,
+                  }}
+                />
+              </div>
+              <div className="text-xs font-bold tabular-nums shrink-0 w-10 text-right" style={{ color: accent }}>
+                {p.count}×
+              </div>
+              {hasScores && (
+                <div className="text-xs text-[#6b7280] tabular-nums shrink-0 w-20 text-right">
+                  {avgScore !== null ? `~${avgScore.toLocaleString()}` : '—'}
+                </div>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/analytics/element-usage-trend.test.tsx
+++ b/src/components/analytics/element-usage-trend.test.tsx
@@ -8,6 +8,13 @@ describe('ElementUsageTrend', () => {
     expect(screen.getByText(/No element usage data available/i)).toBeInTheDocument()
   })
 
+  it('renders a hint when only one season is provided (chart needs ≥2 points)', () => {
+    render(
+      <ElementUsageTrend data={[{ label: 'Jan', ts: 1, counts: { 200: 3 } }]} />
+    )
+    expect(screen.getByText(/At least two seasons/i)).toBeInTheDocument()
+  })
+
   it('renders chart heading when data is provided', () => {
     render(
       <ElementUsageTrend

--- a/src/components/analytics/element-usage-trend.test.tsx
+++ b/src/components/analytics/element-usage-trend.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ElementUsageTrend } from './element-usage-trend'
+
+describe('ElementUsageTrend', () => {
+  it('renders empty state with no data', () => {
+    render(<ElementUsageTrend data={[]} />)
+    expect(screen.getByText(/No element usage data available/i)).toBeInTheDocument()
+  })
+
+  it('renders chart heading when data is provided', () => {
+    render(
+      <ElementUsageTrend
+        data={[
+          { label: 'Jan', ts: 1, counts: { 200: 3, 201: 2 } },
+          { label: 'Feb', ts: 2, counts: { 200: 1, 202: 4 } },
+        ]}
+      />
+    )
+    expect(screen.getByText(/Element usage over time/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/analytics/element-usage-trend.test.tsx
+++ b/src/components/analytics/element-usage-trend.test.tsx
@@ -8,11 +8,11 @@ describe('ElementUsageTrend', () => {
     expect(screen.getByText(/No element usage data available/i)).toBeInTheDocument()
   })
 
-  it('renders a hint when only one season is provided (chart needs ≥2 points)', () => {
+  it('renders chart heading even with only one season (BarChart handles single bar)', () => {
     render(
       <ElementUsageTrend data={[{ label: 'Jan', ts: 1, counts: { 200: 3 } }]} />
     )
-    expect(screen.getByText(/At least two seasons/i)).toBeInTheDocument()
+    expect(screen.getByText(/Element usage over time/i)).toBeInTheDocument()
   })
 
   it('renders chart heading when data is provided', () => {

--- a/src/components/analytics/element-usage-trend.tsx
+++ b/src/components/analytics/element-usage-trend.tsx
@@ -93,7 +93,7 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
     return { rows: built, elementsPresent: presentIds }
   }, [data, normalize])
 
-  if (rows.length === 0) {
+  if (rows.length < 2) {
     return (
       <section
         className="p-6 text-center text-[#6b7280] text-sm"
@@ -104,7 +104,9 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
             'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
         }}
       >
-        No element usage data available.
+        {rows.length === 0
+          ? 'No element usage data available.'
+          : 'At least two seasons of data are needed for the element trend chart.'}
       </section>
     )
   }

--- a/src/components/analytics/element-usage-trend.tsx
+++ b/src/components/analytics/element-usage-trend.tsx
@@ -74,19 +74,23 @@ function CustomTooltip({ active, payload, label }: any) {
 export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }: ElementUsageTrendProps) {
   const { rows, elementsPresent } = useMemo(() => {
     const present = new Set<number>()
+    for (const p of data) {
+      for (const k of Object.keys(p.counts)) present.add(Number(k))
+    }
+    const presentIds = Array.from(present).sort()
     const sorted = [...data].sort((a, b) => a.ts - b.ts)
     const built: ChartRow[] = sorted.map(p => {
       const total = Object.values(p.counts).reduce((s, v) => s + v, 0) || 1
       const row: ChartRow = { ts: p.ts, label: p.label }
-      for (const [k, v] of Object.entries(p.counts)) {
-        const id = Number(k)
-        present.add(id)
+      // Fill every element key (default 0) so recharts stack math doesn't see undefined → NaN
+      for (const id of presentIds) {
         const name = ELEMENT_NAMES[id] ?? `Element ${id}`
+        const v = p.counts[id] ?? 0
         row[name] = normalize ? Number(((v / total) * 100).toFixed(1)) : v
       }
       return row
     })
-    return { rows: built, elementsPresent: Array.from(present).sort() }
+    return { rows: built, elementsPresent: presentIds }
   }, [data, normalize])
 
   if (rows.length === 0) {
@@ -126,13 +130,14 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
       </p>
       <div style={{ width: '100%', height: 280 }}>
         <ResponsiveContainer>
-          <AreaChart data={rows} margin={{ top: 12, right: 16, left: 0, bottom: 8 }} stackOffset={normalize ? 'expand' : 'none'}>
+          <AreaChart data={rows} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#1e2438" />
             <XAxis dataKey="label" stroke="#6b7280" tick={{ fontSize: 11 }} />
             <YAxis
               stroke="#6b7280"
               tick={{ fontSize: 11 }}
-              tickFormatter={normalize ? (v: number) => `${Math.round(v * 100)}%` : undefined}
+              domain={normalize ? [0, 100] : undefined}
+              tickFormatter={normalize ? (v: number) => `${Math.round(v)}%` : undefined}
             />
             <Tooltip content={<CustomTooltip />} />
             <Legend wrapperStyle={{ fontSize: 11, color: '#e8e0cc' }} />

--- a/src/components/analytics/element-usage-trend.tsx
+++ b/src/components/analytics/element-usage-trend.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react'
 import {
-  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid,
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid,
 } from 'recharts'
 
 // Element id -> display name. Aligned with the analytics components in the repo.
@@ -93,7 +93,7 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
     return { rows: built, elementsPresent: presentIds }
   }, [data, normalize])
 
-  if (rows.length < 2) {
+  if (rows.length === 0 || elementsPresent.length === 0) {
     return (
       <section
         className="p-6 text-center text-[#6b7280] text-sm"
@@ -104,9 +104,7 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
             'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
         }}
       >
-        {rows.length === 0
-          ? 'No element usage data available.'
-          : 'At least two seasons of data are needed for the element trend chart.'}
+        No element usage data available.
       </section>
     )
   }
@@ -132,7 +130,7 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
       </p>
       <div style={{ width: '100%', height: 280 }}>
         <ResponsiveContainer>
-          <AreaChart data={rows} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <BarChart data={rows} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#1e2438" />
             <XAxis dataKey="label" stroke="#6b7280" tick={{ fontSize: 11 }} />
             <YAxis
@@ -141,24 +139,22 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
               domain={normalize ? [0, 100] : undefined}
               tickFormatter={normalize ? (v: number) => `${Math.round(v)}%` : undefined}
             />
-            <Tooltip content={<CustomTooltip />} />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(255,255,255,0.04)' }} />
             <Legend wrapperStyle={{ fontSize: 11, color: '#e8e0cc' }} />
             {elementsPresent.map(id => {
               const name = ELEMENT_NAMES[id] ?? `Element ${id}`
               const color = ELEMENT_COLORS[id] ?? '#6b7280'
               return (
-                <Area
+                <Bar
                   key={id}
-                  type="monotone"
                   dataKey={name}
-                  stackId="1"
-                  stroke={color}
+                  stackId="elements"
                   fill={color}
-                  fillOpacity={0.55}
+                  fillOpacity={0.85}
                 />
               )
             })}
-          </AreaChart>
+          </BarChart>
         </ResponsiveContainer>
       </div>
     </section>

--- a/src/components/analytics/element-usage-trend.tsx
+++ b/src/components/analytics/element-usage-trend.tsx
@@ -1,11 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import {
-  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid,
-} from 'recharts'
 
-// Element id -> display name. Aligned with the analytics components in the repo.
 const ELEMENT_NAMES: Record<number, string> = {
   200: 'Physical',
   201: 'Ice',
@@ -36,64 +32,43 @@ export interface ElementSeasonPoint {
 interface ElementUsageTrendProps {
   data: ElementSeasonPoint[]
   accent?: string
-  /** Render counts as % of season total instead of raw counts. */
-  normalize?: boolean
 }
 
-interface ChartRow {
+interface Row {
   ts: number
   label: string
-  [elementName: string]: number | string
+  total: number
+  /** id -> { count, pct } */
+  byId: Record<number, { count: number; pct: number }>
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function CustomTooltip({ active, payload, label }: any) {
-  if (!active || !payload?.length) return null
-  return (
-    <div
-      className="text-xs text-[#e8e0cc] px-3 py-2"
-      style={{
-        background: '#0d0f17',
-        border: '1px solid rgba(0,212,255,0.3)',
-        clipPath: 'polygon(0 0,calc(100% - 6px) 0,100% 6px,100% 100%,6px 100%,0 calc(100% - 6px))',
-      }}
-    >
-      <div className="font-bold text-[#00d4ff] mb-1">{label}</div>
-      {payload
-        .slice()
-        .sort((a: { value: number }, b: { value: number }) => b.value - a.value)
-        .map((p: { name: string; value: number; color: string }, i: number) => (
-          <div key={i} style={{ color: p.color }}>
-            {p.name}: {typeof p.value === 'number' ? p.value.toFixed(1) : p.value}
-          </div>
-        ))}
-    </div>
-  )
-}
-
-export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }: ElementUsageTrendProps) {
-  const { rows, elementsPresent } = useMemo(() => {
+export function ElementUsageTrend({ data, accent = '#00d4ff' }: ElementUsageTrendProps) {
+  const { rows, presentIds } = useMemo(() => {
     const present = new Set<number>()
     for (const p of data) {
-      for (const k of Object.keys(p.counts)) present.add(Number(k))
-    }
-    const presentIds = Array.from(present).sort()
-    const sorted = [...data].sort((a, b) => a.ts - b.ts)
-    const built: ChartRow[] = sorted.map(p => {
-      const total = Object.values(p.counts).reduce((s, v) => s + v, 0) || 1
-      const row: ChartRow = { ts: p.ts, label: p.label }
-      // Fill every element key (default 0) so recharts stack math doesn't see undefined → NaN
-      for (const id of presentIds) {
-        const name = ELEMENT_NAMES[id] ?? `Element ${id}`
-        const v = p.counts[id] ?? 0
-        row[name] = normalize ? Number(((v / total) * 100).toFixed(1)) : v
+      for (const k of Object.keys(p.counts)) {
+        const id = Number(k)
+        if (Number.isFinite(id) && id in ELEMENT_NAMES) present.add(id)
       }
-      return row
-    })
-    return { rows: built, elementsPresent: presentIds }
-  }, [data, normalize])
+    }
+    const ids = Array.from(present).sort((a, b) => a - b)
 
-  if (rows.length === 0 || elementsPresent.length === 0) {
+    const sorted = [...data].sort((a, b) => a.ts - b.ts)
+    const built: Row[] = sorted.map(p => {
+      const byId: Record<number, { count: number; pct: number }> = {}
+      let total = 0
+      for (const id of ids) total += p.counts[id] ?? 0
+      for (const id of ids) {
+        const count = p.counts[id] ?? 0
+        byId[id] = { count, pct: total > 0 ? (count / total) * 100 : 0 }
+      }
+      return { ts: p.ts, label: p.label, total, byId }
+    })
+
+    return { rows: built, presentIds: ids }
+  }, [data])
+
+  if (rows.length === 0 || presentIds.length === 0) {
     return (
       <section
         className="p-6 text-center text-[#6b7280] text-sm"
@@ -119,43 +94,55 @@ export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }
           'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
       }}
     >
-      <div className="text-[10px] font-bold tracking-[0.2em] uppercase mb-1" style={{ color: accent, opacity: 0.8 }}>
+      <div
+        className="text-[10px] font-bold tracking-[0.2em] uppercase mb-1"
+        style={{ color: accent, opacity: 0.8 }}
+      >
         Element Trend
       </div>
-      <h3 className="text-lg font-black text-[#e8e0cc] mb-1">
-        Element usage over time
-      </h3>
+      <h3 className="text-lg font-black text-[#e8e0cc] mb-1">Element usage over time</h3>
       <p className="text-xs text-[#6b7280] mb-4">
-        {normalize ? 'Share of agent picks per element each season.' : 'Raw count of agent picks per element each season.'}
+        Share of agent picks per element each season.
       </p>
-      <div style={{ width: '100%', height: 280 }}>
-        <ResponsiveContainer>
-          <BarChart data={rows} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#1e2438" />
-            <XAxis dataKey="label" stroke="#6b7280" tick={{ fontSize: 11 }} />
-            <YAxis
-              stroke="#6b7280"
-              tick={{ fontSize: 11 }}
-              domain={normalize ? [0, 100] : undefined}
-              tickFormatter={normalize ? (v: number) => `${Math.round(v)}%` : undefined}
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mb-3 text-[11px]">
+        {presentIds.map(id => (
+          <div key={id} className="flex items-center gap-1.5 text-[#e8e0cc]">
+            <span
+              className="inline-block w-2.5 h-2.5"
+              style={{ background: ELEMENT_COLORS[id] }}
             />
-            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(255,255,255,0.04)' }} />
-            <Legend wrapperStyle={{ fontSize: 11, color: '#e8e0cc' }} />
-            {elementsPresent.map(id => {
-              const name = ELEMENT_NAMES[id] ?? `Element ${id}`
-              const color = ELEMENT_COLORS[id] ?? '#6b7280'
-              return (
-                <Bar
-                  key={id}
-                  dataKey={name}
-                  stackId="elements"
-                  fill={color}
-                  fillOpacity={0.85}
-                />
-              )
-            })}
-          </BarChart>
-        </ResponsiveContainer>
+            {ELEMENT_NAMES[id]}
+          </div>
+        ))}
+      </div>
+
+      {/* Stacked bars (one per season) */}
+      <div className="flex flex-col gap-2">
+        {rows.map(row => (
+          <div key={row.ts} className="flex items-center gap-3">
+            <div className="text-[10px] tabular-nums text-[#6b7280] w-16 shrink-0 truncate">
+              {row.label}
+            </div>
+            <div className="flex-1 h-5 bg-[#1e2438] flex overflow-hidden">
+              {presentIds.map(id => {
+                const seg = row.byId[id]
+                if (!seg || seg.pct <= 0) return null
+                return (
+                  <div
+                    key={id}
+                    title={`${ELEMENT_NAMES[id]}: ${seg.count} (${seg.pct.toFixed(1)}%)`}
+                    style={{ width: `${seg.pct}%`, background: ELEMENT_COLORS[id] }}
+                  />
+                )
+              })}
+            </div>
+            <div className="text-[10px] tabular-nums text-[#6b7280] w-10 text-right shrink-0">
+              {row.total}
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   )

--- a/src/components/analytics/element-usage-trend.tsx
+++ b/src/components/analytics/element-usage-trend.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid,
+} from 'recharts'
+
+// Element id -> display name. Aligned with the analytics components in the repo.
+const ELEMENT_NAMES: Record<number, string> = {
+  200: 'Physical',
+  201: 'Ice',
+  202: 'Fire',
+  203: 'Ether',
+  204: 'Electric',
+  205: 'Anomaly',
+}
+
+const ELEMENT_COLORS: Record<number, string> = {
+  200: '#f5c842',
+  201: '#60a5fa',
+  202: '#f97316',
+  203: '#a855f7',
+  204: '#22c55e',
+  205: '#ef4444',
+}
+
+export interface ElementSeasonPoint {
+  /** Display label, e.g. "Mar 2026". */
+  label: string
+  /** Sortable timestamp (ms since epoch). */
+  ts: number
+  /** Map of element_type -> usage count for the season. */
+  counts: Record<number, number>
+}
+
+interface ElementUsageTrendProps {
+  data: ElementSeasonPoint[]
+  accent?: string
+  /** Render counts as % of season total instead of raw counts. */
+  normalize?: boolean
+}
+
+interface ChartRow {
+  ts: number
+  label: string
+  [elementName: string]: number | string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function CustomTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null
+  return (
+    <div
+      className="text-xs text-[#e8e0cc] px-3 py-2"
+      style={{
+        background: '#0d0f17',
+        border: '1px solid rgba(0,212,255,0.3)',
+        clipPath: 'polygon(0 0,calc(100% - 6px) 0,100% 6px,100% 100%,6px 100%,0 calc(100% - 6px))',
+      }}
+    >
+      <div className="font-bold text-[#00d4ff] mb-1">{label}</div>
+      {payload
+        .slice()
+        .sort((a: { value: number }, b: { value: number }) => b.value - a.value)
+        .map((p: { name: string; value: number; color: string }, i: number) => (
+          <div key={i} style={{ color: p.color }}>
+            {p.name}: {typeof p.value === 'number' ? p.value.toFixed(1) : p.value}
+          </div>
+        ))}
+    </div>
+  )
+}
+
+export function ElementUsageTrend({ data, accent = '#00d4ff', normalize = true }: ElementUsageTrendProps) {
+  const { rows, elementsPresent } = useMemo(() => {
+    const present = new Set<number>()
+    const sorted = [...data].sort((a, b) => a.ts - b.ts)
+    const built: ChartRow[] = sorted.map(p => {
+      const total = Object.values(p.counts).reduce((s, v) => s + v, 0) || 1
+      const row: ChartRow = { ts: p.ts, label: p.label }
+      for (const [k, v] of Object.entries(p.counts)) {
+        const id = Number(k)
+        present.add(id)
+        const name = ELEMENT_NAMES[id] ?? `Element ${id}`
+        row[name] = normalize ? Number(((v / total) * 100).toFixed(1)) : v
+      }
+      return row
+    })
+    return { rows: built, elementsPresent: Array.from(present).sort() }
+  }, [data, normalize])
+
+  if (rows.length === 0) {
+    return (
+      <section
+        className="p-6 text-center text-[#6b7280] text-sm"
+        style={{
+          background: `${accent}0d`,
+          border: `1px solid ${accent}33`,
+          clipPath:
+            'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
+        }}
+      >
+        No element usage data available.
+      </section>
+    )
+  }
+
+  return (
+    <section
+      className="p-5"
+      style={{
+        background: `${accent}0d`,
+        border: `1px solid ${accent}33`,
+        clipPath:
+          'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
+      }}
+    >
+      <div className="text-[10px] font-bold tracking-[0.2em] uppercase mb-1" style={{ color: accent, opacity: 0.8 }}>
+        Element Trend
+      </div>
+      <h3 className="text-lg font-black text-[#e8e0cc] mb-1">
+        Element usage over time
+      </h3>
+      <p className="text-xs text-[#6b7280] mb-4">
+        {normalize ? 'Share of agent picks per element each season.' : 'Raw count of agent picks per element each season.'}
+      </p>
+      <div style={{ width: '100%', height: 280 }}>
+        <ResponsiveContainer>
+          <AreaChart data={rows} margin={{ top: 12, right: 16, left: 0, bottom: 8 }} stackOffset={normalize ? 'expand' : 'none'}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1e2438" />
+            <XAxis dataKey="label" stroke="#6b7280" tick={{ fontSize: 11 }} />
+            <YAxis
+              stroke="#6b7280"
+              tick={{ fontSize: 11 }}
+              tickFormatter={normalize ? (v: number) => `${Math.round(v * 100)}%` : undefined}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ fontSize: 11, color: '#e8e0cc' }} />
+            {elementsPresent.map(id => {
+              const name = ELEMENT_NAMES[id] ?? `Element ${id}`
+              const color = ELEMENT_COLORS[id] ?? '#6b7280'
+              return (
+                <Area
+                  key={id}
+                  type="monotone"
+                  dataKey={name}
+                  stackId="1"
+                  stroke={color}
+                  fill={color}
+                  fillOpacity={0.55}
+                />
+              )
+            })}
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  )
+}

--- a/src/components/analytics/inflation-tracker.test.tsx
+++ b/src/components/analytics/inflation-tracker.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { InflationTracker } from './inflation-tracker'
+
+describe('InflationTracker', () => {
+  it('renders empty state when no series have points', () => {
+    render(<InflationTracker series={[]} />)
+    expect(screen.getByText(/Not enough data/i)).toBeInTheDocument()
+  })
+
+  it('renders the chart heading when at least one series has data', () => {
+    render(
+      <InflationTracker
+        series={[
+          {
+            name: 'Deadly Assault',
+            color: '#f5c842',
+            points: [
+              { ts: 1, label: 'Jan', scorePct: 80 },
+              { ts: 2, label: 'Feb', scorePct: 75 },
+            ],
+          },
+        ]}
+      />
+    )
+    expect(screen.getByText(/Score % across seasons/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/analytics/inflation-tracker.tsx
+++ b/src/components/analytics/inflation-tracker.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend,
+  CartesianGrid, ReferenceLine,
+} from 'recharts'
+
+export interface InflationSeriesPoint {
+  /** Sortable timestamp (ms since epoch). Used to align series across modes. */
+  ts: number
+  /** Display label for this season (e.g. "Mar 2026"). */
+  label: string
+  /** Score expressed as a 0–100 percentage of that season's max. */
+  scorePct: number
+}
+
+export interface InflationSeries {
+  /** Mode display name. */
+  name: string
+  /** Hex accent color. */
+  color: string
+  points: InflationSeriesPoint[]
+}
+
+interface InflationTrackerProps {
+  series: InflationSeries[]
+}
+
+interface MergedRow {
+  ts: number
+  label: string
+  [seriesName: string]: number | string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function CustomTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null
+  return (
+    <div
+      className="text-xs text-[#e8e0cc] px-3 py-2"
+      style={{
+        background: '#0d0f17',
+        border: '1px solid rgba(0,212,255,0.3)',
+        clipPath: 'polygon(0 0,calc(100% - 6px) 0,100% 6px,100% 100%,6px 100%,0 calc(100% - 6px))',
+      }}
+    >
+      <div className="font-bold text-[#00d4ff] mb-1">{label}</div>
+      {payload.map((p: { name: string; value: number; color: string }, i: number) => (
+        <div key={i} style={{ color: p.color }}>
+          {p.name}: {p.value.toFixed(1)}%
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function InflationTracker({ series }: InflationTrackerProps) {
+  const merged = useMemo<MergedRow[]>(() => {
+    const byTs = new Map<number, MergedRow>()
+    for (const s of series) {
+      for (const p of s.points) {
+        const row = byTs.get(p.ts) ?? { ts: p.ts, label: p.label }
+        row[s.name] = Number(p.scorePct.toFixed(2))
+        byTs.set(p.ts, row)
+      }
+    }
+    return Array.from(byTs.values()).sort((a, b) => a.ts - b.ts)
+  }, [series])
+
+  // Trend indicator: average of last 3 vs first 3 points across all series
+  const trend = useMemo(() => {
+    const allPcts = merged.flatMap(row =>
+      series.map(s => row[s.name]).filter((v): v is number => typeof v === 'number')
+    )
+    if (allPcts.length < 4) return null
+    const head = allPcts.slice(0, Math.max(3, Math.floor(allPcts.length / 4)))
+    const tail = allPcts.slice(-Math.max(3, Math.floor(allPcts.length / 4)))
+    const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length
+    const delta = avg(tail) - avg(head)
+    return { delta, headAvg: avg(head), tailAvg: avg(tail) }
+  }, [merged, series])
+
+  if (merged.length === 0) {
+    return (
+      <section
+        className="p-6 text-center text-[#6b7280] text-sm"
+        style={{
+          background: 'rgba(168,85,247,0.06)',
+          border: '1px solid rgba(168,85,247,0.2)',
+          clipPath:
+            'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
+        }}
+      >
+        Not enough data for inflation trend yet.
+      </section>
+    )
+  }
+
+  return (
+    <section
+      className="p-5"
+      style={{
+        background: 'rgba(168,85,247,0.05)',
+        border: '1px solid rgba(168,85,247,0.2)',
+        clipPath:
+          'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
+      }}
+    >
+      <div className="flex items-baseline justify-between gap-3 mb-1 flex-wrap">
+        <div>
+          <div className="text-[10px] font-bold tracking-[0.2em] uppercase text-[#a855f7] opacity-80">
+            Inflation Tracker
+          </div>
+          <h3 className="text-lg font-black text-[#e8e0cc]">Score % across seasons</h3>
+        </div>
+        {trend && (
+          <div className="text-xs text-[#6b7280]">
+            <span className="font-bold" style={{ color: trend.delta >= 0 ? '#22c55e' : '#ef4444' }}>
+              {trend.delta >= 0 ? '▲' : '▼'} {Math.abs(trend.delta).toFixed(1)} pts
+            </span>{' '}
+            (avg {trend.headAvg.toFixed(1)}% → {trend.tailAvg.toFixed(1)}%)
+          </div>
+        )}
+      </div>
+      <p className="text-xs text-[#6b7280] mb-4 max-w-2xl">
+        Each line is your score as a percentage of that season&apos;s max — a flat line means content scales
+        with you; a downward trend means it&apos;s outpacing you.
+      </p>
+      <div style={{ width: '100%', height: 280 }}>
+        <ResponsiveContainer>
+          <LineChart data={merged} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1e2438" />
+            <XAxis dataKey="label" stroke="#6b7280" tick={{ fontSize: 11 }} />
+            <YAxis
+              stroke="#6b7280"
+              tick={{ fontSize: 11 }}
+              domain={[0, 100]}
+              tickFormatter={v => `${v}%`}
+            />
+            <ReferenceLine y={75} stroke="#1e2438" strokeDasharray="2 4" />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ fontSize: 11, color: '#e8e0cc' }} />
+            {series.map(s => (
+              <Line
+                key={s.name}
+                type="monotone"
+                dataKey={s.name}
+                stroke={s.color}
+                strokeWidth={2}
+                dot={{ r: 3, fill: s.color }}
+                activeDot={{ r: 5 }}
+                connectNulls
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  )
+}

--- a/src/components/analytics/records-panel.test.tsx
+++ b/src/components/analytics/records-panel.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { RecordsPanel } from './records-panel'
+
+describe('RecordsPanel', () => {
+  it('renders nothing when records array is empty', () => {
+    const { container } = render(<RecordsPanel title="Personal Bests" records={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders each record label and value', () => {
+    render(
+      <RecordsPanel
+        title="Personal Bests"
+        records={[
+          { label: 'Top Score', value: '12,345', sublabel: 'Mar 26' },
+          { label: 'Best Rank', value: 'top 0.05%' },
+        ]}
+      />
+    )
+    expect(screen.getByText('Personal Bests')).toBeInTheDocument()
+    expect(screen.getByText('Top Score')).toBeInTheDocument()
+    expect(screen.getByText('12,345')).toBeInTheDocument()
+    expect(screen.getByText('Mar 26')).toBeInTheDocument()
+    expect(screen.getByText('Best Rank')).toBeInTheDocument()
+    expect(screen.getByText('top 0.05%')).toBeInTheDocument()
+  })
+})

--- a/src/components/analytics/records-panel.tsx
+++ b/src/components/analytics/records-panel.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+export interface RecordItem {
+  label: string
+  value: string | number
+  sublabel?: string
+}
+
+interface RecordsPanelProps {
+  title: string
+  records: RecordItem[]
+  accent?: string
+}
+
+export function RecordsPanel({ title, records, accent = '#00d4ff' }: RecordsPanelProps) {
+  if (records.length === 0) return null
+
+  const accentDim = `${accent}1a`
+  const accentBorder = `${accent}33`
+
+  return (
+    <section
+      className="p-5"
+      style={{
+        background: accentDim,
+        border: `1px solid ${accentBorder}`,
+        clipPath:
+          'polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px))',
+      }}
+    >
+      <div
+        className="text-[10px] font-bold tracking-[0.2em] uppercase mb-4"
+        style={{ color: accent, opacity: 0.8 }}
+      >
+        {title}
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        {records.map((r, i) => (
+          <div
+            key={`${r.label}-${i}`}
+            className="p-3 bg-[#0d0f17] border border-[#1e2438]"
+            style={{
+              clipPath:
+                'polygon(0 0, calc(100% - 6px) 0, 100% 6px, 100% 100%, 6px 100%, 0 calc(100% - 6px))',
+            }}
+          >
+            <div className="text-[9px] font-bold tracking-[0.15em] uppercase text-[#6b7280] mb-1">
+              {r.label}
+            </div>
+            <div className="text-lg font-black text-[#e8e0cc] leading-tight">{r.value}</div>
+            {r.sublabel && (
+              <div className="text-[10px] text-[#6b7280] mt-1 truncate" title={r.sublabel}>
+                {r.sublabel}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/deadly-assault/da-analytics.tsx
+++ b/src/components/deadly-assault/da-analytics.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react'
 import {
   AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid,
-  Tooltip, ResponsiveContainer, ReferenceLine, Cell, ScatterChart, Scatter, ZAxis
+  Tooltip, ResponsiveContainer, ReferenceLine, Cell
 } from 'recharts'
 import type { DeadlyAssaultData } from "@/types/deadly-assault"
 import { percentile } from '@/lib/utils'

--- a/src/components/ui/grade-badge.tsx
+++ b/src/components/ui/grade-badge.tsx
@@ -1,4 +1,4 @@
-import { mapStarRatingToGrade, getGradeColorClass } from '@/utils/ratingMapper';
+import { mapStarRatingToGrade } from '@/utils/ratingMapper';
 
 interface GradeBadgeProps {
   stars: number;

--- a/src/lib/analytics-extractors.ts
+++ b/src/lib/analytics-extractors.ts
@@ -1,0 +1,265 @@
+import type { DeadlyAssaultData, TimeStamp } from '@/types/deadly-assault'
+import type { ShiyuDefenseData } from '@/types/shiyu-defense'
+import type { VoidFrontData } from '@/types/void-front'
+import type { RecordItem } from '@/components/analytics/records-panel'
+import type { InflationSeriesPoint } from '@/components/analytics/inflation-tracker'
+import type { ElementSeasonPoint } from '@/components/analytics/element-usage-trend'
+import type { SynergyTeam } from '@/components/analytics/agent-synergy-heatmap'
+
+// ── Time helpers ────────────────────────────────────────────────────────────
+
+function tsToMs(ts: TimeStamp | undefined): number {
+  if (!ts) return 0
+  return Date.UTC(ts.year, (ts.month ?? 1) - 1, ts.day ?? 1, ts.hour ?? 0, ts.minute ?? 0, ts.second ?? 0)
+}
+
+function tsToLabel(ts: TimeStamp | undefined): string {
+  if (!ts) return '—'
+  const month = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][(ts.month ?? 1) - 1]
+  return `${month} ${String(ts.year).slice(-2)}`
+}
+
+function unixSecondsToMs(s: number | undefined): number {
+  if (!s || !Number.isFinite(s)) return 0
+  return s * 1000
+}
+
+function unixSecondsToLabel(s: number | undefined): string {
+  if (!s || !Number.isFinite(s)) return '—'
+  const d = new Date(s * 1000)
+  const month = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][d.getUTCMonth()]
+  return `${month} ${String(d.getUTCFullYear()).slice(-2)}`
+}
+
+function fmt(n: number | undefined): string {
+  return typeof n === 'number' ? n.toLocaleString() : '—'
+}
+
+// ── Inflation series ────────────────────────────────────────────────────────
+
+export function buildDaInflation(data: DeadlyAssaultData[]): InflationSeriesPoint[] {
+  return data
+    .map(d => {
+      const score = d?.data?.total_score
+      const max = d?.data?.total_max_score
+      if (!score || !max) return null
+      return {
+        ts: tsToMs(d.data.end_time),
+        label: tsToLabel(d.data.end_time),
+        scorePct: (score / max) * 100,
+      }
+    })
+    .filter((x): x is InflationSeriesPoint => x !== null)
+}
+
+export function buildHadalInflation(data: ShiyuDefenseData[]): InflationSeriesPoint[] {
+  return data
+    .filter(d => d.metadata?.sourceVersion === 'v2' && d.data.hadal_score !== undefined && d.data.hadal_max_score)
+    .map(d => ({
+      ts: tsToMs(d.data.hadal_end_time),
+      label: tsToLabel(d.data.hadal_end_time),
+      scorePct: (d.data.hadal_score! / d.data.hadal_max_score!) * 100,
+    }))
+}
+
+export function buildVfInflation(data: VoidFrontData[]): InflationSeriesPoint[] {
+  return data
+    .map(d => {
+      const brief = d?.data?.void_front_battle_abstract_info_brief
+      if (!brief?.total_score || !brief?.max_score) return null
+      return {
+        ts: unixSecondsToMs(brief.end_ts),
+        label: unixSecondsToLabel(brief.end_ts),
+        scorePct: (brief.total_score / brief.max_score) * 100,
+      }
+    })
+    .filter((x): x is InflationSeriesPoint => x !== null)
+}
+
+// ── Records ─────────────────────────────────────────────────────────────────
+
+export function buildDaRecords(data: DeadlyAssaultData[]): RecordItem[] {
+  if (data.length === 0) return []
+  const seasonsWithMax = data.filter(d => d.data?.total_max_score)
+  const bestSeason = [...seasonsWithMax].sort(
+    (a, b) => (b.data.total_score / b.data.total_max_score) - (a.data.total_score / a.data.total_max_score)
+  )[0]
+  const allRuns = data.flatMap(d => d.data?.list ?? [])
+  const bestRun = [...allRuns].sort((a, b) => (b.score ?? 0) - (a.score ?? 0))[0]
+  const mostStars = [...data].sort((a, b) => (b.data?.total_star ?? 0) - (a.data?.total_star ?? 0))[0]
+  const bestRank = [...data]
+    .filter(d => typeof d.data?.rank_percent === 'number')
+    .sort((a, b) => a.data.rank_percent - b.data.rank_percent)[0]
+
+  const records: RecordItem[] = [
+    { label: 'Best Score%', value: bestSeason ? `${((bestSeason.data.total_score / bestSeason.data.total_max_score) * 100).toFixed(1)}%` : '—', sublabel: bestSeason ? tsToLabel(bestSeason.data.end_time) : undefined },
+    { label: 'Top Single Run', value: fmt(bestRun?.score), sublabel: bestRun?.boss?.[0]?.name },
+    { label: 'Most Stars', value: fmt(mostStars?.data?.total_star), sublabel: mostStars ? tsToLabel(mostStars.data.end_time) : undefined },
+    { label: 'Best Rank', value: bestRank ? `top ${bestRank.data.rank_percent / 100}%` : '—', sublabel: bestRank ? tsToLabel(bestRank.data.end_time) : undefined },
+    { label: 'Seasons Tracked', value: data.length },
+  ]
+  return records
+}
+
+export function buildHadalRecords(data: ShiyuDefenseData[]): RecordItem[] {
+  const v2 = data.filter(d => d.metadata?.sourceVersion === 'v2' && d.data.hadal_score !== undefined)
+  if (v2.length === 0) return []
+  const bestSeason = [...v2].sort(
+    (a, b) => (b.data.hadal_score! / (b.data.hadal_max_score ?? 1)) -
+              (a.data.hadal_score! / (a.data.hadal_max_score ?? 1))
+  )[0]
+  const topScore = [...v2].sort((a, b) => (b.data.hadal_score ?? 0) - (a.data.hadal_score ?? 0))[0]
+  const sRuns = v2.filter(d => {
+    const r = d.data.rating_list?.[0]?.rating
+    return r === 'S' || r === 'S+'
+  }).length
+
+  return [
+    { label: 'Best Score%', value: bestSeason && bestSeason.data.hadal_max_score
+      ? `${((bestSeason.data.hadal_score! / bestSeason.data.hadal_max_score) * 100).toFixed(1)}%`
+      : '—',
+      sublabel: bestSeason ? tsToLabel(bestSeason.data.hadal_begin_time) : undefined },
+    { label: 'Top Score', value: fmt(topScore?.data?.hadal_score), sublabel: topScore ? tsToLabel(topScore.data.hadal_begin_time) : undefined },
+    { label: 'S+ / S Seasons', value: sRuns },
+    { label: 'Seasons Tracked', value: v2.length },
+  ]
+}
+
+export function buildVfRecords(data: VoidFrontData[]): RecordItem[] {
+  if (data.length === 0) return []
+  const briefs = data.map(d => d?.data?.void_front_battle_abstract_info_brief).filter(Boolean) as NonNullable<VoidFrontData['data']['void_front_battle_abstract_info_brief']>[]
+  if (briefs.length === 0) return []
+  const topScore = [...briefs].sort((a, b) => (b.total_score ?? 0) - (a.total_score ?? 0))[0]
+  const bestPct = [...briefs]
+    .filter(b => b.max_score)
+    .sort((a, b) => (b.total_score / b.max_score) - (a.total_score / a.max_score))[0]
+  const bestRank = [...briefs]
+    .filter(b => typeof b.rank_percent === 'number')
+    .sort((a, b) => a.rank_percent - b.rank_percent)[0]
+
+  return [
+    { label: 'Top Score', value: fmt(topScore?.total_score), sublabel: unixSecondsToLabel(topScore?.end_ts) },
+    { label: 'Best Score%', value: bestPct ? `${((bestPct.total_score / bestPct.max_score) * 100).toFixed(1)}%` : '—', sublabel: unixSecondsToLabel(bestPct?.end_ts) },
+    { label: 'Best Rank', value: bestRank ? `top ${(bestRank.rank_percent / 100).toFixed(2)}%` : '—', sublabel: unixSecondsToLabel(bestRank?.end_ts) },
+    { label: 'Seasons Tracked', value: briefs.length },
+  ]
+}
+
+// ── Element usage ───────────────────────────────────────────────────────────
+
+export function buildDaElementUsage(data: DeadlyAssaultData[]): ElementSeasonPoint[] {
+  return data
+    .map(d => {
+      const counts: Record<number, number> = {}
+      for (const run of d.data?.list ?? []) {
+        for (const a of run.avatar_list ?? []) {
+          counts[a.element_type] = (counts[a.element_type] ?? 0) + 1
+        }
+      }
+      return {
+        label: tsToLabel(d.data?.end_time),
+        ts: tsToMs(d.data?.end_time),
+        counts,
+      }
+    })
+    .filter(p => Object.keys(p.counts).length > 0)
+}
+
+export function buildHadalElementUsage(data: ShiyuDefenseData[]): ElementSeasonPoint[] {
+  return data
+    .filter(d => d.metadata?.sourceVersion === 'v2')
+    .map(d => {
+      const counts: Record<number, number> = {}
+      for (const floor of d.data?.all_floor_detail ?? []) {
+        for (const a of floor.node_1?.avatars ?? []) {
+          counts[a.element_type] = (counts[a.element_type] ?? 0) + 1
+        }
+        for (const a of floor.node_2?.avatars ?? []) {
+          counts[a.element_type] = (counts[a.element_type] ?? 0) + 1
+        }
+      }
+      return {
+        label: tsToLabel(d.data?.hadal_begin_time),
+        ts: tsToMs(d.data?.hadal_begin_time),
+        counts,
+      }
+    })
+    .filter(p => Object.keys(p.counts).length > 0)
+}
+
+export function buildVfElementUsage(data: VoidFrontData[]): ElementSeasonPoint[] {
+  return data
+    .map(d => {
+      const counts: Record<number, number> = {}
+      for (const ch of d?.data?.main_challenge_record_list ?? []) {
+        for (const a of ch.avatar_list ?? []) {
+          counts[a.element_type] = (counts[a.element_type] ?? 0) + 1
+        }
+      }
+      const bossMain = d?.data?.boss_challenge_record?.main_challenge_record
+      if (bossMain) {
+        for (const a of bossMain.avatar_list ?? []) {
+          counts[a.element_type] = (counts[a.element_type] ?? 0) + 1
+        }
+      }
+      return {
+        label: unixSecondsToLabel(d?.data?.void_front_battle_abstract_info_brief?.end_ts),
+        ts: unixSecondsToMs(d?.data?.void_front_battle_abstract_info_brief?.end_ts),
+        counts,
+      }
+    })
+    .filter(p => Object.keys(p.counts).length > 0)
+}
+
+// ── Synergy teams ───────────────────────────────────────────────────────────
+
+export function buildDaTeams(data: DeadlyAssaultData[]): SynergyTeam[] {
+  const teams: SynergyTeam[] = []
+  for (const d of data) {
+    for (const run of d.data?.list ?? []) {
+      const icons: Record<number, string> = {}
+      const ids: number[] = []
+      for (const a of run.avatar_list ?? []) {
+        ids.push(a.id)
+        if (a.role_square_url) icons[a.id] = a.role_square_url
+      }
+      if (ids.length >= 2) teams.push({ agentIds: ids, agentIcons: icons, score: run.score })
+    }
+  }
+  return teams
+}
+
+export function buildHadalTeams(data: ShiyuDefenseData[]): SynergyTeam[] {
+  const teams: SynergyTeam[] = []
+  for (const d of data.filter(x => x.metadata?.sourceVersion === 'v2')) {
+    for (const floor of d.data?.all_floor_detail ?? []) {
+      for (const node of [floor.node_1, floor.node_2]) {
+        if (!node) continue
+        const icons: Record<number, string> = {}
+        const ids: number[] = []
+        for (const a of node.avatars ?? []) {
+          ids.push(a.id)
+          if (a.role_square_url) icons[a.id] = a.role_square_url
+        }
+        if (ids.length >= 2) teams.push({ agentIds: ids, agentIcons: icons })
+      }
+    }
+  }
+  return teams
+}
+
+export function buildVfTeams(data: VoidFrontData[]): SynergyTeam[] {
+  const teams: SynergyTeam[] = []
+  for (const d of data) {
+    for (const ch of d?.data?.main_challenge_record_list ?? []) {
+      const icons: Record<number, string> = {}
+      const ids: number[] = []
+      for (const a of ch.avatar_list ?? []) {
+        ids.push(a.id)
+        if (a.role_square_url) icons[a.id] = a.role_square_url
+      }
+      if (ids.length >= 2) teams.push({ agentIds: ids, agentIcons: icons, score: ch.score })
+    }
+  }
+  return teams
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -16,3 +16,10 @@ class ResizeObserverMock {
 }
 ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver =
   ResizeObserverMock
+
+// jsdom always reports 0×0 for layout boxes, which makes recharts ResponsiveContainer
+// log a "width(0) and height(0)" warning. Stub the box size so charts mount cleanly.
+Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 800 })
+Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 400 })
+Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 800 })
+Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 400 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -23,3 +23,9 @@ Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true
 Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 400 })
 Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 800 })
 Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 400 })
+Element.prototype.getBoundingClientRect = function () {
+  return {
+    x: 0, y: 0, top: 0, left: 0, right: 800, bottom: 400, width: 800, height: 400,
+    toJSON: () => ({}),
+  } as DOMRect
+}


### PR DESCRIPTION
## Summary

Phase 2 of the analytics expansion — adds four reusable analytics components, plus per-mode data extractors, wired into a new "Insights" tab on each game-mode page and the home page.

- **InflationTracker** (home page) — line chart of normalized score% per season across all 3 modes with a head-to-tail trend indicator. Finally makes the repo name (Zenless-Inflation-Watcher) deliver on its promise.
- **RecordsPanel** — generic personal-bests grid (label / value / sublabel)
- **AgentSynergyHeatmap** — counts agent co-occurrence across teams, surfaces the top pairs with intensity bars and avg score
- **ElementUsageTrend** — stacked-area chart of element-type picks over time (defaults to share-of-total)

All four are wired into a new **Insights** tab on Deadly Assault, Shiyu Defense (Hadal v2 only), and Void Front. Per-mode data extraction lives in `src/lib/analytics-extractors.ts` so the components stay generic and storybook-ready (Phase 4).

## Why

These features deliver on the project's stated purpose (tracking score "inflation" over time) and turn raw season data into actionable insight without forcing the user to scroll through history pages.

## Reviewer notes

- The home page is now an **async server component** — data is fetched at build time, alongside the existing static export
- Element name/color mappings are duplicated between `src/components/analytics/element-usage-trend.tsx` and the per-mode analytics components. Consolidating into `src/types/shared.ts` is a good follow-up but out of scope here — the existing `shared.ts` mapping conflicts with the analytics components, so picking the canonical IDs is its own decision
- Hadal Insights tab only renders for v2 data (v1 lacks the `hadal_score` field needed for normalization)
- 11/11 smoke tests pass; `npm run lint` and `npm run build` clean

## Test plan

- [x] `npm test` — 11 passing
- [x] `npm run build` — clean
- [x] Visit `/` — see InflationTracker render with all 3 modes
- [x] Visit `/deadly-assault` → Insights tab — records, element trend, synergy heatmap
- [x] Visit `/shiyu-defense` → Insights tab (Hadal v2 only)
- [x] Visit `/void-front` → Insights tab
