### PR TITLE
Patrol Log: deep links, mobile polish, agent chart, VF backfill, build fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "next build",
     "start": "next start",
     "export": "next export",
-    "lint": "next lint",
+    "lint": "tsc --noEmit && next lint",
     "migrate:filenames": "node scripts/migrate-filenames.js",
     "check-architecture": "node scripts/validate-architecture.js",
     "docs": "echo 'Architecture Documentation:' && echo '📚 Full Guide: docs/CLIENT-SERVER-ARCHITECTURE.md' && echo '✅ Checklist: docs/ARCHITECTURE-CHECKLIST.md' && echo '🏗️ System: docs/ARCHITECTURE-SYSTEM.md' && echo '🔧 Linting: docs/ARCHITECTURE-LINTING.md'",

--- a/src/components/patrol-log/other-views.tsx
+++ b/src/components/patrol-log/other-views.tsx
@@ -17,6 +17,7 @@ type RunExt = {
 type DAExt = {
   schedule_id?: number;
   total_score: number;
+  total_max_score?: number;
   total_star: number;
   rank_percent: number;
   start_time?: Record<string, number>;


### PR DESCRIPTION
## Summary

- **Shareable deep links** — hash routing extended to `#view/periodId` (e.g. `#shiyu/62046`); all three views resolve on mount and update the URL as the scrubber moves
- **All-time agent usage bar chart** on dashboard — replaces the static avatar grid, ranks all agents cross-mode with color-mix gradient intensity
- **VF period 201 backfilled** — sub-challenges ingested from alternate raw schema (`main_challenge_record_list`); Boss Record panel now shows the last-node squad
- **`scripts/build-data.js`** — consolidates all one-off patch scripts; reads raw files from scratch and writes `zzz-data.json` + per-view split files
- **Per-view lazy fetching** — `zzz-data.json` split into `zzz-shiyu.json`, `zzz-deadly.json`, `zzz-voidfront.json`; app-shell fetches only what the active view needs
- **Mobile modal bottom sheet** — slides up from screen edge, full-width, 92dvh cap
- **Modal squad grid compact on mobile** — single-column stacked layout so agents don't overflow
- **Modal animation smoothed** — replaced overshoot spring curve with clean decelerate; keyframe simplified to translateY-only
- **Close button rotation toned down** — 90deg to 20deg on hover
- **Shiyu floor ledger 2-col on mobile**, taller period scrubber chips
- **Lazy image loading** on agent avatars
- **`tsc --noEmit` added to lint script** — type errors caught at lint time, not only at build time
- **Build fix** — `total_max_score` added to `DAExt` type

## Test plan

- [x] Visit `#shiyu/62046` directly — correct period should be pre-selected
- [x] Move scrubber on each view — URL hash should update
- [x] Open a floor modal on mobile — should appear as bottom sheet, squad cards single-column
- [x] Dashboard agent chart shows all agents ranked cross-mode
- [x] Void Front period 201 shows sub-challenges and last-node squad in Boss Record
- [x] `npm run lint` catches type errors
- [x] `npm run build` succeeds with no errors
