### PR TITLE
fix: correct ROOT path in build-data.js for CI (fix ENOENT)

### DIFF
--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -3,7 +3,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = join(__dirname, '..', '..', '..', '..');
+const ROOT = join(__dirname, '..');
 const OUT = join(__dirname, '..', 'public', 'data', 'zzz-data.json');
 
 function mapAvatar(a) {


### PR DESCRIPTION
## Summary

`build-data.js` used `join(__dirname, '..', '..', '..', '..')` — 4 levels up, which happened to work inside the git worktree but resolves to `/home/runner/` in CI. The raw data directories (`shiyu/`, `deadlyAssault/`, `voidFront/`) were never found, so `zzz-data.json` was never written, and `split-data.js` failed with ENOENT.

Fix: use `join(__dirname, '..')` — one level up from `scripts/`, which is always the project root.

## Test plan

- [ ] CI build completes without ENOENT on `zzz-data.json`
- [ ] `zzz-shiyu.json`, `zzz-deadly.json`, `zzz-voidfront.json` return 200 on GitHub Pages

Generated with [Claude Code](https://claude.com/claude-code)