### PR TITLE
fix: resolve GitHub Pages 404s — basePath prefix + public/data dir in CI

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,9 @@ const nextConfig = {
   output: 'export', // important for static site
   basePath: isProd ? '/Zenless-Inflation-Watcher' : '',
   assetPrefix: isProd ? '/Zenless-Inflation-Watcher/' : '',
+  env: {
+    NEXT_PUBLIC_BASE_PATH: isProd ? '/Zenless-Inflation-Watcher' : '',
+  },
   // Pin Next's project root so it doesn't walk up to a stray lockfile in $HOME
   // and resolve modules against the wrong dependency tree (which causes
   // "Object.c [as require]" failures during prerender on Windows).

--- a/src/components/patrol-log/app-shell.tsx
+++ b/src/components/patrol-log/app-shell.tsx
@@ -8,11 +8,13 @@ import type { ZZZData, AvatarInfo, ShiyuPeriod, DeadlyAssaultPeriod, VoidFrontPe
 
 const VALID_VIEWS = ['dashboard', 'shiyu', 'deadly', 'voidfront'];
 
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 /** Map from view name to the JSON file it needs and the ZZZData key it populates. */
 const VIEW_FILES: Record<string, { file: string; key: keyof ZZZData }> = {
-  shiyu:     { file: '/data/zzz-shiyu.json',    key: 'shiyu' },
-  deadly:    { file: '/data/zzz-deadly.json',   key: 'deadlyAssault' },
-  voidfront: { file: '/data/zzz-voidfront.json', key: 'voidFront' },
+  shiyu:     { file: `${BASE}/data/zzz-shiyu.json`,    key: 'shiyu' },
+  deadly:    { file: `${BASE}/data/zzz-deadly.json`,   key: 'deadlyAssault' },
+  voidfront: { file: `${BASE}/data/zzz-voidfront.json`, key: 'voidFront' },
 };
 
 const DASHBOARD_DEPS = ['shiyu', 'deadly', 'voidfront'] as const;


### PR DESCRIPTION
## Summary

- **Root cause of 404s identified**: `fetch()` ignores Next.js `basePath` — on GitHub Pages the app was requesting `/data/zzz-shiyu.json` instead of `/Zenless-Inflation-Watcher/data/zzz-shiyu.json`
- **Fix**: expose `NEXT_PUBLIC_BASE_PATH` via `next.config.js` and prefix all `VIEW_FILES` fetch paths with it at build time
- **Also fixes**: `public/data/` directory not existing in fresh CI checkout (gitignored) — `build-data.js` now calls `mkdirSync({ recursive: true })` before writing, and a `.gitkeep` is committed to track the folder
- **Also fixes**: `.gitignore` pattern `data/` was too broad and matched `public/data/` — tightened to `/data/` (root-only) + `public/data/*.json`
- **Also fixes**: `split-data.js` auto-bootstraps `build-data.js` if `zzz-data.json` is missing, making it self-healing regardless of call order

## Test plan

- [ ] `zzz-shiyu.json`, `zzz-deadly.json`, `zzz-voidfront.json` return 200 on GitHub Pages
- [ ] All three views load data on `https://whitefallen.github.io/Zenless-Inflation-Watcher/`
- [ ] Local dev still works (base path is empty string in dev)

Generated with [Claude Code](https://claude.com/claude-code)