### PR TITLE
fix: remove pulsing dot and blur from page transitions (sensory)

### DIFF
--- a/src/app/patrol-log.css
+++ b/src/app/patrol-log.css
@@ -458,8 +458,8 @@
 @keyframes cornerStamp { 0% { transform: translateX(50px) rotate(8deg); opacity: 0; } 60% { transform: translateX(-3px) rotate(-1deg); opacity: 1; } 100% { transform: translateX(0) rotate(0); opacity: 1; } }
 @keyframes heartbeat { 0%, 100% { transform: scale(1); } 20% { transform: scale(1.4); } 40% { transform: scale(1); } }
 @keyframes floorReveal { from { opacity: 0; transform: translateY(40px) rotateX(-15deg); transform-origin: top; } to { opacity: 1; transform: translateY(0) rotateX(0); } }
-@keyframes viewEnter { from { opacity: 0; transform: translateX(20px); filter: blur(6px); } to { opacity: 1; transform: translateX(0); filter: blur(0); } }
-@keyframes viewLeave { from { opacity: 1; transform: translateX(0); } to { opacity: 0; transform: translateX(-20px); filter: blur(4px); } }
+@keyframes viewEnter { from { opacity: 0; transform: translateX(10px); } to { opacity: 1; transform: translateX(0); } }
+@keyframes viewLeave { from { opacity: 1; } to { opacity: 0; } }
 @keyframes modalIn { 0% { opacity: 0; transform: translateY(12px); } 100% { opacity: 1; transform: translateY(0); } }
 @keyframes backdropIn { from { opacity: 0; backdrop-filter: blur(0px); } to { opacity: 1; backdrop-filter: blur(4px); } }
 @keyframes drawLine { from { stroke-dashoffset: 2000; } to { stroke-dashoffset: 0; } }

--- a/src/components/patrol-log/shared.tsx
+++ b/src/components/patrol-log/shared.tsx
@@ -123,7 +123,7 @@ export function TopBar({ active, onNav }: { active: string; onNav: (v: string) =
         </div>
         <div style={{ flex: 1 }} />
         <div className="topbar-live" style={{ display: 'flex', alignItems: 'center', padding: '0 16px', gap: 12, fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: 'var(--ink-dim)' }}>
-          <span style={{ display: 'inline-block', width: 8, height: 8, background: 'var(--acid)', borderRadius: '50%', animation: 'pulse 2s ease-in-out infinite' }} />
+          <span style={{ display: 'inline-block', width: 8, height: 8, background: 'var(--acid)', borderRadius: '50%' }} />
           <span>LIVE</span>
         </div>
         <button className="hamburger" onClick={() => { setMenuOpen(o => { if (!o) window.scrollTo({ top: 0, behavior: 'smooth' }); return !o; }); }} aria-label="Menu">


### PR DESCRIPTION
## Summary

- **Pulsing LIVE dot removed** — the continuously animating green dot on the topbar was distracting and could cause sensory issues; now static
- **Page transition blur removed** — view enter/leave animations used `filter: blur(6px)` which caused a visible blur-and-twitch effect on every navigation; replaced with a simple opacity fade and a subtle 10px slide on enter only

## Test plan

- [ ] Topbar LIVE dot is static (no pulsing)
- [ ] Navigating between views fades cleanly with no blur or twitching

Generated with [Claude Code](https://claude.com/claude-code)