### PR TITLE
fix: PWA revamp — refresh, install banner, transitions, cache strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:watch": "vitest",
     "prepare": "husky",
     "auth": "node auth.js",
-    "predev": "node scripts/copy-data-to-public.js && node scripts/generateManifest.js",
+    "predev": "node scripts/copy-data-to-public.js && node scripts/build-data.js && node scripts/split-data.js && node scripts/generateManifest.js",
     "dev": "next dev",
     "prebuild": "node scripts/copy-data-to-public.js && node scripts/build-data.js && node scripts/split-data.js && node scripts/generateManifest.js",
     "build": "next build",

--- a/src/app/patrol-log.css
+++ b/src/app/patrol-log.css
@@ -381,8 +381,7 @@
 [data-patrol-log] .reveal-on-view.in-view { opacity: 1; transform: translateY(0); }
 
 /* ---- View transitions ---- */
-[data-patrol-log] .view-entering { animation: viewEnter 0.4s cubic-bezier(0.2, 0.8, 0.2, 1); }
-[data-patrol-log] .view-leaving { animation: viewLeave 0.22s ease-in forwards; }
+[data-patrol-log] .view-entering { animation: viewEnter 0.25s ease-out; }
 
 /* ---- Loading ---- */
 [data-patrol-log] .pulse { animation: pulse 1.6s ease-in-out infinite; position: relative; }

--- a/src/app/patrol-log.css
+++ b/src/app/patrol-log.css
@@ -216,7 +216,7 @@
   transition: transform 0.2s;
   cursor: pointer;
 }
-[data-patrol-log] .brand-block:hover { animation: brandFlicker 0.6s steps(1, end); transform: scale(1.02); }
+[data-patrol-log] .brand-block:hover { transform: scale(1.02); }
 [data-patrol-log] .nav-links { display: flex; gap: 0; height: 100%; }
 [data-patrol-log] .nav-link {
   display: flex;
@@ -364,7 +364,7 @@
 /* ---- Period chip ---- */
 [data-patrol-log] .period-chip { flex-shrink: 0; display: flex; flex-direction: column; align-items: stretch; background: var(--asphalt-2); border: 1.5px solid var(--line); padding: 8px 10px; cursor: pointer; min-width: 100px; min-height: 56px; transition: all 0.2s cubic-bezier(0.2, 0.8, 0.2, 1); position: relative; }
 [data-patrol-log] .period-chip:hover { border-color: var(--ink-dim); background: var(--asphalt-3); transform: translateY(-3px); }
-[data-patrol-log] .period-chip.active { border-color: var(--tape); background: var(--asphalt-3); transform: translateY(-3px) scale(1.04); animation: activePulse 2s ease-in-out infinite; }
+[data-patrol-log] .period-chip.active { border-color: var(--tape); background: var(--asphalt-3); transform: translateY(-3px) scale(1.04); }
 [data-patrol-log] .period-chip.active::before { content: ''; position: absolute; left: 0; right: 0; bottom: -1.5px; height: 2px; background: var(--tape); }
 
 /* ---- Chart tooltip ---- */
@@ -419,7 +419,7 @@
 [data-patrol-log] .panel-grid > .panel:nth-child(6) { animation: floorReveal 0.5s 400ms cubic-bezier(0.2, 0.8, 0.2, 1) backwards; }
 
 /* ---- Hairline live cursor ---- */
-[data-patrol-log] .hairline.live::after { content: '_'; margin-left: 4px; animation: blink 1s steps(1) infinite; color: var(--tape); }
+[data-patrol-log] .hairline.live::after { content: '_'; margin-left: 4px; color: var(--tape); }
 
 /* ---- Scrollbars ---- */
 [data-patrol-log] ::-webkit-scrollbar { width: 10px; height: 10px; }
@@ -458,7 +458,7 @@
 @keyframes cornerStamp { 0% { transform: translateX(50px) rotate(8deg); opacity: 0; } 60% { transform: translateX(-3px) rotate(-1deg); opacity: 1; } 100% { transform: translateX(0) rotate(0); opacity: 1; } }
 @keyframes heartbeat { 0%, 100% { transform: scale(1); } 20% { transform: scale(1.4); } 40% { transform: scale(1); } }
 @keyframes floorReveal { from { opacity: 0; transform: translateY(40px) rotateX(-15deg); transform-origin: top; } to { opacity: 1; transform: translateY(0) rotateX(0); } }
-@keyframes viewEnter { from { opacity: 0; transform: translateX(10px); } to { opacity: 1; transform: translateX(0); } }
+@keyframes viewEnter { from { opacity: 0; } to { opacity: 1; } }
 @keyframes viewLeave { from { opacity: 1; } to { opacity: 0; } }
 @keyframes modalIn { 0% { opacity: 0; transform: translateY(12px); } 100% { opacity: 1; transform: translateY(0); } }
 @keyframes backdropIn { from { opacity: 0; backdrop-filter: blur(0px); } to { opacity: 1; backdrop-filter: blur(4px); } }

--- a/src/app/patrol-log.css
+++ b/src/app/patrol-log.css
@@ -403,7 +403,7 @@
 }
 
 /* ---- Fade-up ---- */
-[data-patrol-log] .fade-up { animation: fadeUp 0.4s ease-out backwards; }
+[data-patrol-log] .fade-up { }
 
 /* ---- Slide right ---- */
 [data-patrol-log] .slide-right { animation: slideRight 0.3s ease-out backwards; }

--- a/src/app/patrol-log.css
+++ b/src/app/patrol-log.css
@@ -381,7 +381,6 @@
 [data-patrol-log] .reveal-on-view.in-view { opacity: 1; transform: translateY(0); }
 
 /* ---- View transitions ---- */
-[data-patrol-log] .view-entering { animation: viewEnter 0.25s ease-out; }
 
 /* ---- Loading ---- */
 [data-patrol-log] .pulse { animation: pulse 1.6s ease-in-out infinite; position: relative; }

--- a/src/components/patrol-log/app-shell.tsx
+++ b/src/components/patrol-log/app-shell.tsx
@@ -47,7 +47,6 @@ export function PatrolLogApp() {
   const loadingRef = useRef<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [agentModal, setAgentModal] = useState<AvatarInfo | null>(null);
-  const [navigating, setNavigating] = useState(false);
 
   const loadSlice = useCallback((v: string) => {
     if (!(v in VIEW_FILES)) return;
@@ -78,13 +77,9 @@ export function PatrolLogApp() {
     if (nextView === view && pid == null) return;
     const hash = pid != null ? `${nextView}/${pid}` : nextView;
     window.location.hash = hash;
-    setNavigating(true);
-    setTimeout(() => {
-      setView(nextView);
-      setInitialPeriodId(pid ?? null);
-      window.scrollTo(0, 0);
-      setNavigating(false);
-    }, 220);
+    setView(nextView);
+    setInitialPeriodId(pid ?? null);
+    window.scrollTo(0, 0);
   }, [view]);
 
   // Browser back/forward — re-parse the hash on every hashchange.
@@ -144,7 +139,7 @@ export function PatrolLogApp() {
   return (
     <>
       <TopBar active={view} onNav={goTo} />
-      <div key={view + String(initialPeriodId)} className={navigating ? 'view-leaving' : 'view-entering'}>
+      <div key={view + String(initialPeriodId)} className="view-entering">
         {view === 'dashboard'  && <Dashboard  data={data} onNav={goTo} />}
         {view === 'shiyu'      && <ShiyuView  data={data} onAgent={setAgentModal} initialPeriodId={initialPeriodId} onPeriodChange={pid => goTo('shiyu', pid)} />}
         {view === 'voidfront'  && <VoidFrontView data={data} onAgent={setAgentModal} initialPeriodId={initialPeriodId} onPeriodChange={pid => goTo('voidfront', pid)} />}


### PR DESCRIPTION
## Summary

- **Refresh button fixed** — correctly reloads after SW activation with `skipWaiting:true`
- **Install banner dismiss** — 7-day cooldown now respected on all devices (iOS + non-iOS)
- **Offline fallback** — `offline.html` wired as document fallback in SW config
- **SW cache strategy** — tiered rules replacing single NetworkFirst-everything
- **Dead `useCache` hook** — removed
- **Pulsing LIVE dot** — removed, now static
- **Page transition effects** — removed `brandFlicker`, `activePulse`, `blink`, `fade-up`, and all view enter/leave animations; navigation is now fully instant with no opacity or movement effects
- **`predev` script** — now generates split JSON files so `npm run dev` works without a separate data step

## Test plan

- [ ] Refresh button reloads the page after a SW update
- [ ] Install banner does not reappear within 7 days of dismissal
- [ ] Going offline after first load shows `offline.html`
- [ ] Navigating between all views is instant with no flash, fade, or movement
- [ ] `npm run dev` starts without 404s on data files

Generated with [Claude Code](https://claude.com/claude-code)